### PR TITLE
fix(search-list): change type of hits to any[]

### DIFF
--- a/packages/search-list/SearchList.tsx
+++ b/packages/search-list/SearchList.tsx
@@ -30,7 +30,7 @@ const SearchExplanation = styled(H4)`
 `
 
 export interface SearchListProps {
-  hits: [any]
+  hits: any[]
   isLoading?: boolean
   isError?: boolean
   listItem: (arg0: any) => React.ReactNode


### PR DESCRIPTION
"use the type of the elements followed by [] to denote an array of that element type"