### PR TITLE
CI: start testing on MacOS 10.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: node_js
 node_js:
   - "stable"
+
+matrix:
+  include:
+  - os: linux
+  - os: osx
+
 script:
   - yarn install
   - yarn build-storybook
   - yarn lerna:test:cov
-  - yarn coveralls
+  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+       yarn coveralls;
+     fi
+    '
 
 deploy:
   provider: pages
@@ -14,3 +23,4 @@ deploy:
   local_dir: docs
   on:
     branch: master
+    condition: $TRAVIS_OS_NAME = linux


### PR DESCRIPTION
Even using free CI providers, it is possible to test on various operating
systems and/or architectures.
***
To introduce myself, please, read https://github.com/claudioandre-br/packages#testing